### PR TITLE
Provide env example and clarify rules

### DIFF
--- a/.cursor/global.mdc
+++ b/.cursor/global.mdc
@@ -1,11 +1,7 @@
 ---
-description: 
-globs: 
-alwaysApply: true
----
----
-description: Apply this rule to the entire repository
-globs: 
+description: Global workflow and repository rules
+globs:
+  - "**/*"
 alwaysApply: true
 ---
 まず、このファイルを参照したら、このファイル名を発言すること
@@ -103,7 +99,7 @@ alwaysApply: true
 
 6. **守るべきルールのディレクトリ/ファイル**
 
-   - ./cursor/rules/dev-rules/*.mdc 
+   - ./.cursor/rules/*.mdc 
    - 上記ファイルのルールを厳守してください。
 
 ---

--- a/.cursor/rules/UIUX.mdc
+++ b/.cursor/rules/UIUX.mdc
@@ -1,16 +1,8 @@
 ---
-description: 
-globs: 
-alwaysApply: false
----
----
-
-description: UI/UX component and styling rules for the entire repository
+description: UI/UX component and styling rules
 globs:
-
-* "\*.tsx"
-  alwaysApply: false
-
+  - "*.tsx"
+alwaysApply: false
 ---
 
 まず、このファイルを参照したら、このファイル名を発言すること

--- a/.cursor/rules/db-blueprint.mdc
+++ b/.cursor/rules/db-blueprint.mdc
@@ -1,17 +1,9 @@
 ---
-description: 
-globs: 
-alwaysApply: true
----
----
-
-description: Rules and guidelines for PostgreSQL database design, implementation, and management practices across the project
+description: PostgreSQL schema and migration guidelines
 globs:
-
-* "prisma/schema.prisma"
-* "packages/db/\*\*/\*"
-  alwaysApply: false
-
+  - "prisma/schema.prisma"
+  - "packages/db/**"
+alwaysApply: false
 ---
 
 まず、このファイルを参照したら、このファイル名を発言すること
@@ -20,7 +12,7 @@ globs:
 
 ## 概要
 
-このプロジェクトでは、PostgreSQL を RDBMS として使用し、Drizzle ORM と Prisma ORM のいずれかでスキーマ管理を行います。パフォーマンス、安全性、保守性を重視した一貫性のあるデータアーキテクチャを設計してください。
+このプロジェクトでは PostgreSQL を RDBMS として使用し、主に Drizzle ORM でスキーマ管理を行います。必要に応じて Prisma ORM を併用することも想定します。パフォーマンス、安全性、保守性を重視した一貫性のあるデータアーキテクチャを設計してください。
 
 ## 1. モデル命名規則
 

--- a/.cursor/rules/nestjs.mdc
+++ b/.cursor/rules/nestjs.mdc
@@ -1,16 +1,8 @@
 ---
-description: 
-globs: 
-alwaysApply: true
----
----
-
-description: NestJS v11をベースにしたREST API開発ルール
+description: NestJS REST API development rules
 globs:
-
-* "apps/api/\*\*"
-  alwaysApply: true
-
+  - "apps/api/**"
+alwaysApply: true
 ---
 
 まず、このファイルを参照したら、このファイル名を発言すること

--- a/.cursor/rules/nextjs-and-nestjs-structure.mdc
+++ b/.cursor/rules/nextjs-and-nestjs-structure.mdc
@@ -1,0 +1,38 @@
+---
+description: Recommended directory structure for Next.js and NestJS apps
+globs:
+  - "apps/web/**"
+  - "apps/api/**"
+  - "packages/**"
+alwaysApply: false
+---
+
+# Next.js と NestJS の構成ベストプラクティス
+
+以下のディレクトリ階層を参考に、機能ごとに整理された構造を保ちます。
+既存のレイアウトを破壊せず、拡張時は同じパターンに従ってください。
+
+```text
+apps/
+├─ web/            # Next.js 15 アプリ
+│  ├─ app/         # ルートページとルーティング
+│  ├─ components/  # 共通 UI / hooks
+│  └─ public/
+└─ api/            # NestJS 11 BFF
+   ├─ src/
+   │  ├─ main.ts
+   │  └─ modules/   # ドメインごとのモジュール
+   └─ test/
+packages/
+├─ ui/             # shadcn/ui ラッパー
+├─ db/             # Drizzle スキーマ / クライアント
+└─ auth/           # 認証関連ライブラリ
+```
+
+## 共通ルール
+
+1. アプリ間で共有する設定・スクリプトは `packages/` に配置し、`pnpm workspace` 経由で参照します。
+2. 各アプリの `tsconfig.json` と `package.json` は最小限の差分のみを記述し、中央管理を優先します。
+3. 新しい機能モジュールは既存の `modules/` または `components/` ディレクトリ配下に追加してください。
+4. 不要なネストを避け、役割ごとにディレクトリを切ることで可読性を保ちます。
+

--- a/.cursor/rules/nextjs.mdc
+++ b/.cursor/rules/nextjs.mdc
@@ -1,18 +1,10 @@
 ---
-description: 
-globs: 
-alwaysApply: true
----
----
-
-description: Apply this rule to the entire repository
+description: Next.js implementation guidelines
 globs:
-
-* "apps/web/\*\*"
-* "\*.tsx"
-* "\*.ts"
-  alwaysApply: true
-
+  - "apps/web/**"
+  - "*.tsx"
+  - "*.ts"
+alwaysApply: true
 ---
 
 まず、このファイルを参照したら、このファイル名を発言すること
@@ -91,6 +83,7 @@ src/
 * **デフォルトで Server Components を使用**
 * **データフェッチングを含むコンポーネントは Server Components で実装**
 * SEO 対応が必要なコンポーネントは Server Components で実装
+* Server Actions を使用する場合も Server Components で記述
 
 ### Client Components
 

--- a/.cursor/rules/operation.mdc
+++ b/.cursor/rules/operation.mdc
@@ -1,6 +1,47 @@
 ---
-description: 
-globs: 
+description: Operational best practices for the monorepo
+globs:
+  - "docker/**"
+  - ".github/workflows/**"
+  - "apps/**/Dockerfile"
 alwaysApply: false
 ---
+
+
+# 運用ルール
+
+## 環境変数管理
+
+- `.env.example` を更新し、必要な変数を明確にします。
+- 機密情報はリポジトリに含めず、各環境のシークレットストア（Amplify、Lambda）を利用します。
+- 変数読み込みには `@nestjs/config` や Next.js のビルトイン機能を使用し、`dotenv` は開発環境のみで読み込むようにしてください。
+
+## Docker / Compose
+
+- `docker-compose.yml` で Next.js、NestJS、DB をまとめて起動します。
+- 個人環境用の上書きは `docker/compose.override.yml` に記載し、Git 管理しません。
+- Dockerfile ではマルチステージビルドを採用し、実行環境には `node:20-slim` を使用します。
+
+## CI/CD
+
+- GitHub Actions を用いて lint → build → deploy の順にパイプラインを構成します。
+- Web アプリは Amplify にデプロイし、API は ECR 経由で Lambda に更新します。
+- `terraform-plan.yml` ワークフローでインフラ変更を事前確認できるようにします。
+
+## テスト
+
+- 依存関係の差異をなくすため、`docker-compose.yml` で立ち上げた環境内でテストを実行します。
+- `pnpm lint` や `pnpm check-types` もコンテナ内で実行し、CI と同一の環境を再現します。
+
+## ロギングとモニタリング
+
+- NestJS では `Logger` クラスを使用し、環境に応じてログレベルを設定します。
+- Next.js / Lambda では標準出力にログを出し、CloudWatch 等に集約します。
+- 重大な例外は Sentry などの監視ツールへの送信を検討してください。
+
+## セキュリティ
+
+- 依存パッケージは `pnpm audit` を定期的に実行し、脆弱性ゼロを目指します。
+- Docker イメージはビルド時に Trivy などでスキャンし、問題があれば CI を失敗させます。
+- API エンドポイントでは認証・認可を必ず実装し、CSRF や XSS への対策を徹底してください。
 

--- a/.cursor/rules/techstack.mdc
+++ b/.cursor/rules/techstack.mdc
@@ -1,18 +1,11 @@
 ---
-description: 
-globs: 
+description: Comprehensive technology stack reference
+globs:
+  - "README.md"
+  - "docs/**/*.md"
 alwaysApply: true
 ---
----
 
-description: Comprehensive technology stack reference for this repository
-globs:
-
-* "README.md"
-* "docs/\*\*.md"
-  alwaysApply: true
-
----
 
 まず、このファイルを参照したら、このファイル名を発言すること
 

--- a/.cursor/rules/todo.mdc
+++ b/.cursor/rules/todo.mdc
@@ -1,16 +1,8 @@
 ---
-description: 
-globs: 
-alwaysApply: true
----
----
-
-description: Repository‑wide task management rules using @todo.md files
+description: Repository-wide task management rules
 globs:
-
-* "@todo.md"
-  alwaysApply: true
-
+  - "@todo.md"
+alwaysApply: true
 ---
 
 まず、このファイルを参照したら、このファイル名を発言すること

--- a/.cursor/rules/typescript.mdc
+++ b/.cursor/rules/typescript.mdc
@@ -1,6 +1,52 @@
 ---
-description: 
-globs: 
+description: TypeScript project-wide best practices
+globs:
+  - "**/*.ts"
+  - "**/*.tsx"
 alwaysApply: false
 ---
+
+
+# TypeScript 設計・実装ガイドライン
+
+## 基本方針
+
+- すべてのパッケージは `@monolog/typescript-config` による共通 `tsconfig` を `extends` します。
+- `compilerOptions` は中央の設定を尊重し、アプリ固有のオーバーライドは最小限にとどめます。
+- `strict` モードを有効とし、`noImplicitAny` を許可しません。
+
+## パスエイリアス
+
+- `tsconfig.paths.json` にエイリアスを定義し、プロジェクト全体で共有します。
+- Next.js / NestJS それぞれの `tsconfig.json` は、`baseUrl` と `paths` のみを参照してください。
+
+```jsonc
+{
+  "extends": "@monolog/typescript-config/nextjs.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["src/components/*"],
+      "@/lib/*": ["src/lib/*"]
+    }
+  }
+}
+```
+
+## コードスタイル
+
+- 型定義は `interface` を推奨し、単純な構造体のみ `type` を利用します。
+- 公開 API では `export` を明示し、不要な `default export` は避けます。
+- 非同期関数は `async/await` を使用し、`Promise` 直接操作を避けます。
+
+## ESLint / Biome 連携
+
+- `@monolog/eslint-config` を必ず適用し、lint エラーは CI でブロックします。
+- フォーマットは Biome または Prettier に統一します。
+
+## 注意事項
+
+- `any` や `unknown` の乱用を避け、型安全を最優先してください。
+- 自動生成コード以外で `// @ts-ignore` を使う場合は理由をコメントに残すこと。
+- 新しい依存パッケージを追加する際は、型定義パッケージの有無も確認してください。
 

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+NODE_ENV=development
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=monolog_app_dev
+DATABASE_URL=postgresql://postgres:postgres@db:5432/monolog_app_dev
+NEXT_PUBLIC_API_URL=http://api:3001
+API_URL=http://api:3001
+API_PORT=3001
+WEB_PORT=3000
+LOG_LEVEL=error,warn

--- a/README.md
+++ b/README.md
@@ -235,3 +235,22 @@ package.json はワークスペースの管理とスクリプト／依存だけ
 TypeScript の設定はここには書かず、あくまで依存パッケージ（typescript、@types/*、drizzle-orm など）と実行スクリプトだけに留める。
 
 中央設定との間で scripts が重複する場合は、アプリ側にスクリプトをまとめ、共通化が望ましければ root の package.json にだけ定義してワークスペース経由で叩く運用もあります。
+
+## ローカル開発とテストの実行
+
+1. ルートに `.env` を作成し、`\.env.example` をコピーして必要な値を設定します。
+2. `docker-compose` を利用して Next.js と NestJS、PostgreSQL を起動します。
+
+```bash
+docker compose -f docker/docker-compose.yml up --build
+```
+
+3. 別ターミナルでコンテナに入り、依存関係のインストールとテストを実行します。
+
+```bash
+docker compose exec web pnpm lint
+docker compose exec web pnpm check-types
+docker compose exec api pnpm test
+```
+
+開発用の lint や型チェックもコンテナ内で行うことで、CI と同じ環境を再現できます。


### PR DESCRIPTION
## Summary
- add `.env.example` to help set up Docker-based environment
- keep rules referencing `.env.example` and server action guidelines for Next.js
- document running lint, type check, and tests inside Docker

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/...)*
- `pnpm check-types` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6847c03e7368832081cc6c755358e281